### PR TITLE
Support for RPi / Firefox 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,30 @@ Why would I want that?
 On March 29th congress passed a law that makes it legal for your Internet Service Providers (ISP) to track and sell your personal activity online. This means that things you search for, buy, read, and say can be collected by corporations and used against you. PyNoise contaminates your data with the random websites it visits to make it harder for them to analyze your data.
 source : https://www.govtrack.us/congress/votes/115-2017/h202
 
-How do I use it?
+### How do I use it?
 
 1. Clone the repo
 2. install the only dependency, selenium (pip install selenium)
-3. run the script (python make_noise.py) when you start browsing the internet
+3. run the script (`python make_noise.py`) when you start browsing the internet
 4. close the window when your done
+
+### Headless (Raspberry Pi!)
+
+If you would like to run this project on a Linux server (like a Raspberry Pi) there are a few additional steps:  
+```bash
+$ sudo apt-get install firefox-esr  # chrome/chromedriver doesn't support RPi
+$ sudo apt-get install Xvfb         # virtual display server for selenium to connect to
+$ Xvfb :99 -ac &                    # run a virtual display on port 99
+$ export DISPLAY=:99                # set the display environment variable
+$ python make_noise.py              # make some noise!
+```
 
 Feel free to email me @ nikshepsvn@gmail.com if you have some feedback/suggestions!
 
 ![PyNoise Running](https://i.imgur.com/jF82ACF.png "PyNoise Running")
 
-Current Version V0.02
+Current Version V0.03
+- V0.03 Changelog : added RPi (Firefox) support
 - V0.02 Changelog : added feature for bot to create noise on reddit -- making info from reddit harder to analyze.
 - V0.01 Changelog : First version of bot, Uses WPI's random link generator to visit random sites on the internet.
 

--- a/make_noise.py
+++ b/make_noise.py
@@ -4,7 +4,7 @@ import json
 import urllib2
 import platform
 import time
-from random import randint
+from random import choice, randint
 from selenium import webdriver
 
 #initializing drivers
@@ -54,8 +54,19 @@ print '''Please select which of these sites you visit most often (choose all tha
 5. Amazon
 6. Ebay'''
 
+sites_dict = {
+    '0': 'randomsite()',
+    '1': 'randomreddit()',
+    '2': 'random_fb()',
+    '3': 'random_youtube()',
+    '4': 'random_tumblr()',
+    '5': 'random_amazon()',
+    '6': 'random_ebay()'
+}
+
 #loop to input the data
-linklist = []
+# start with randomsite as default
+linklist = ['0']
 while(1):
     x = raw_input()
     if (x != "S"):
@@ -66,9 +77,11 @@ while(1):
 
 #function to visit random webpages on the internet
 def randomsite():
-        driver.get("http://www.uroulette.com/visit/oqvsoq")
-        time.sleep(randint(0,7))
-        print "currently on site: " + driver.current_url
+    # uroulette url sometimes changes?
+    site = "http://www.uroulette.com/visit/onvpu"
+    driver.get(site)
+    time.sleep(randint(0,7))
+    print "currently on site: " + driver.current_url
 
 #function to randomly visit a subreddit and then browse through it
 def randomreddit():
@@ -84,7 +97,22 @@ def randomreddit():
     print "currently on site: " + driver.current_url
     time.sleep(randint(0,4))
 
+def random_fb():
+    print("Facebook not implemented yet ... ")
+
+def random_youtube():
+    print("Youtube not implemented yet ... ")
+
+def random_tumblr():
+    print("Tumblr not implemented yet ... ")
+
+def random_amazon():
+    print("Amazon not implemented yet ... ")
+
+def random_ebay():
+    print("Ebay not implemented yet ... ")
+
 # loop to start the functions and visits
 while(1):
-    if '1' in linklist:
-        randomreddit()
+    rnd_site = choice(linklist)
+    eval(sites_dict[rnd_site])

--- a/make_noise.py
+++ b/make_noise.py
@@ -1,5 +1,5 @@
 #necassary imports
-import os
+import os, sys
 import json
 import urllib2
 import platform
@@ -14,8 +14,9 @@ print("Starting drivers ... ")
 if 'raspberrypi' in platform.uname() or 'armv7l' == platform.machine():
     if not os.getenv('DISPLAY'):
         print("make sure to start a virtual display:")
-        print("Xfvb :99 -ac &")
+        print("Xvfb :99 -ac &")
         print("export DISPLAY=:99")
+        sys.exit(1)
 
     from selenium.webdriver.firefox.options import Options
     firefox_options = Options()

--- a/make_noise.py
+++ b/make_noise.py
@@ -7,24 +7,42 @@ import time
 from random import randint
 from selenium import webdriver
 
+#initializing drivers
+print("Starting drivers ... ")
+
+# chrome/chromedriver doesn't support RPi
+if 'raspberrypi' in platform.uname() or 'armv7l' == platform.machine():
+    if not os.getenv('DISPLAY'):
+        print("make sure to start a virtual display:")
+        print("Xfvb :99 -ac &")
+        print("export DISPLAY=:99")
+
+    from selenium.webdriver.firefox.options import Options
+    firefox_options = Options()
+    firefox_options.add_argument("--headless")
+    firefox_options.add_argument("user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36")
+
+    p = os.getcwd() + '/geckodriver_arm7'
+    driver = webdriver.Firefox(executable_path=p, firefox_options=firefox_options)
+
+else:
+    #setting up driver to simulate user and also start chrome in background
+    from selenium.webdriver.chrome.options import Options
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36")
+
+    #choosing chrome driver based on OS
+    if 'Linux' in (platform.system()):
+        driver = webdriver.Chrome(os.getcwd()+'/chromedriver_linux',chrome_options=chrome_options)
+    elif 'Windows' in (platform.system()):
+        driver = webdriver.Chrome(os.getcwd()+'/chromedriver.exe',chrome_options=chrome_options)
+    elif 'Darwin' in (platform.system()):
+        driver = webdriver.Chrome(os.getcwd()+'/chromedriver_mac',chrome_options=chrome_options)
+
+
 #starting pynoise..
 print "Generating some random trafific...."
-
-
-#setting up driver to simulate user and also start chrome in background
-from selenium.webdriver.chrome.options import Options
-chrome_options = Options()
-chrome_options.add_argument("--headless")
-chrome_options.add_argument("user-agent=Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36")
-
-#choosing chrome driver based on OS
-if 'Linux' in (platform.system()):
-    driver = webdriver.Chrome(os.getcwd()+'/chromedriver_linux',chrome_options=chrome_options)
-elif 'Windows' in (platform.system()):
-    driver = webdriver.Chrome(os.getcwd()+'/chromedriver.exe',chrome_options=chrome_options)
-elif 'Darwin' in (platform.system()):
-    driver = webdriver.Chrome(os.getcwd()+'/chromedriver_mac',chrome_options=chrome_options)
-
 
 #asking user for input on which sites they browse so pynoise can do a better job contaminating data
 print '''Please select which of these sites you visit most often (choose all that is applicable) (input S when you're finished):


### PR DESCRIPTION
Chrome doesn't officially support RPi Debian:  
* using Firefox instead if system is 'raspberrypi' (still headless)
* using `geckodriver_arm7` from https://github.com/mozilla/geckodriver/releases
* updated README, with minor edits
* added functionality for Firefox could allow the switch to all opensource (i.e. away from Chrome) if desired